### PR TITLE
add support for request configuration

### DIFF
--- a/src/re_graph/core.cljs
+++ b/src/re_graph/core.cljs
@@ -2,12 +2,12 @@
   (:require [re-frame.core :as re-frame]
             [re-graph.internals :as internals]))
 
-(defn default-request-fn [_] {})
+(def default-request-template {})
 
-(defn request-fn
-      "Retrieves the request-fn from db (or returns a default creating an 'empty' request)."
+(defn request-template
+      "Retrieves the request-template from db (or returns a default creating an 'empty' request)."
       [db]
-  (get-in db [:re-graph :request-fn]))
+  (get-in db [:re-graph :request-template]))
 
 (re-frame/reg-event-fx
  ::mutate
@@ -27,7 +27,7 @@
 
      :else
      {::internals/send-http [(get-in db [:re-graph :http-url])
-                             {:request ((request-fn db) db)
+                             {:request (request-template db)
                               :payload {:query (str "mutation " query)
                                         :variables variables}}
                              (fn [payload]
@@ -54,7 +54,7 @@
 
      :else
      {::internals/send-http [(get-in db [:re-graph :http-url])
-                             {:request ((request-fn db) db)
+                             {:request (request-template db)
                               :payload {:query (str "query " query)
                                         :variables variables}}
                              (fn [payload]
@@ -101,9 +101,9 @@
 
 (re-frame/reg-event-fx
  ::init
- (fn [{:keys [db]} [_ {:keys [ws-url http-url request-fn ws-reconnect-timeout resume-subscriptions?]
+ (fn [{:keys [db]} [_ {:keys [ws-url http-url request-template ws-reconnect-timeout resume-subscriptions?]
                        :or {ws-url (internals/default-ws-url)
-                            request-fn default-request-fn
+                            request-template default-request-template
                             http-url "/graphql"
                             ws-reconnect-timeout 5000
                             resume-subscriptions? true}}]]
@@ -118,7 +118,7 @@
                                              :resume-subscriptions? resume-subscriptions?}})
                               (when http-url
                                 {:http-url http-url
-                                 :request-fn request-fn})))}
+                                 :request-template request-template})))}
     (when ws-url
       {::internals/connect-ws [ws-url]}))))
 

--- a/src/re_graph/core.cljs
+++ b/src/re_graph/core.cljs
@@ -2,6 +2,13 @@
   (:require [re-frame.core :as re-frame]
             [re-graph.internals :as internals]))
 
+(defn default-request-fn [_] {})
+
+(defn request-fn
+      "Retrieves the request-fn from db (or returns a default creating an 'empty' request)."
+      [db]
+  (get-in db [:re-graph :request-fn]))
+
 (re-frame/reg-event-fx
  ::mutate
  (fn [{:keys [db]} [_ query variables callback-event :as event]]
@@ -20,7 +27,8 @@
 
      :else
      {::internals/send-http [(get-in db [:re-graph :http-url])
-                             {:payload {:query (str "mutation " query)
+                             {:request ((request-fn db) db)
+                              :payload {:query (str "mutation " query)
                                         :variables variables}}
                              (fn [payload]
                                (re-frame/dispatch (conj callback-event payload)))]})))
@@ -46,7 +54,8 @@
 
      :else
      {::internals/send-http [(get-in db [:re-graph :http-url])
-                             {:payload {:query (str "query " query)
+                             {:request ((request-fn db) db)
+                              :payload {:query (str "query " query)
                                         :variables variables}}
                              (fn [payload]
                                (re-frame/dispatch (conj callback-event payload)))]})))
@@ -92,8 +101,9 @@
 
 (re-frame/reg-event-fx
  ::init
- (fn [{:keys [db]} [_ {:keys [ws-url http-url ws-reconnect-timeout resume-subscriptions?]
+ (fn [{:keys [db]} [_ {:keys [ws-url http-url request-fn ws-reconnect-timeout resume-subscriptions?]
                        :or {ws-url (internals/default-ws-url)
+                            request-fn default-request-fn
                             http-url "/graphql"
                             ws-reconnect-timeout 5000
                             resume-subscriptions? true}}]]
@@ -107,7 +117,8 @@
                                              :reconnect-timeout ws-reconnect-timeout
                                              :resume-subscriptions? resume-subscriptions?}})
                               (when http-url
-                                {:http-url http-url})))}
+                                {:http-url http-url
+                                 :request-fn request-fn})))}
     (when ws-url
       {::internals/connect-ws [ws-url]}))))
 

--- a/src/re_graph/internals.cljs
+++ b/src/re_graph/internals.cljs
@@ -6,8 +6,8 @@
 
 (re-frame/reg-fx
  ::send-http
- (fn [[http-url {:keys [payload]} callback-fn]]
-   (go (let [response (a/<! (http/post http-url {:json-params payload}))]
+ (fn [[http-url {:keys [request payload]} callback-fn]]
+   (go (let [response (a/<! (http/post http-url (assoc request :json-params payload)))]
          (callback-fn (:body response))))))
 
 (re-frame/reg-fx

--- a/test/re_graph/core_test.cljs
+++ b/test/re_graph/core_test.cljs
@@ -252,6 +252,25 @@
            (is (= expected-response-payload
                   (::mutation @app-db)))))))))
 
+
+(deftest http-request-fn-test
+  (run-test-sync
+   (let [expected-http-url "http://foo.bar/graph-ql"
+         expected-request {:with-credentials? false}]
+     (re-frame/dispatch [::re-graph/init {:http-url expected-http-url
+                                          :request-fn (fn [db] expected-request)
+                                          :ws-url nil}])
+     (testing "Request can be specified"
+         (re-frame/reg-fx
+          ::internals/send-http
+          (fn [[http-url {:keys [request payload]} callback-fn]]
+            (is (= expected-request
+                   request))))
+         (re-frame/dispatch [::re-graph/query "{ things { id } }" {:some "variable"} [::on-thing]])
+         (re-frame/dispatch [::re-graph/mutate "don't care" {:some "variable"} [::on-thing]])
+         ))))
+
+
 (deftest non-re-frame-test
   (testing "can call normal functions instead of needing re-frame"
     (run-test-sync

--- a/test/re_graph/core_test.cljs
+++ b/test/re_graph/core_test.cljs
@@ -253,12 +253,12 @@
                   (::mutation @app-db)))))))))
 
 
-(deftest http-request-fn-test
+(deftest http-request-template-test
   (run-test-sync
    (let [expected-http-url "http://foo.bar/graph-ql"
          expected-request {:with-credentials? false}]
      (re-frame/dispatch [::re-graph/init {:http-url expected-http-url
-                                          :request-fn (fn [db] expected-request)
+                                          :request-template expected-request
                                           :ws-url nil}])
      (testing "Request can be specified"
          (re-frame/reg-fx


### PR DESCRIPTION
Hi Oliver,

I found you library today - great approach to support GraphQL in re-frame applications 👍 

However, I immediately ran into a problem when testing a small application agains the demo GraphQL server from `http://graphql.nodaljs.com/`:

```
Failed to load http://graphql.nodaljs.com/graph: Response to preflight request doesn't pass access control check: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. Origin 'http://localhost:3449' is therefore not allowed access. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
```

And, moving from there to my own setup, I'm pretty sure I'll run into problems not being able to specify a CSRF-token header.

So, I identified both problems belonging to issue #11 

Therefore, I'd suggest a PR to add support for request configuration

Request configuration support is required
- to be able to make CORS requests (setting :with-credentials false),
- to add authentication headers
- to add CSRF-token headers

Adding this PR, you will be able to specify a `:request-fn` in the `::re-graph/init` event like this:

```clojure
(re-frame/dispatch [::re-graph/init {:ws-url nil
                                     :http-url "http://graphql.nodaljs.com/graph"
                                     :request-fn (fn [db] {:with-credentials? false})}])
```

The request-fn is using `db` as a parameter to be able to retrieve a CSRF-token from our app-state.

I added a test (and ran successful tests on that in my re-frame application), so I'd be happy to see this PR merged and released. Please feel free to come back to me if you have any doubts or questions on this.

Sincerly,

Chris

P.S.: Thanks a lot :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oliyh/re-graph/13)
<!-- Reviewable:end -->
