### PR TITLE
Add connection-init-payload for websocket

### DIFF
--- a/src/re_graph/core.cljs
+++ b/src/re_graph/core.cljs
@@ -101,11 +101,12 @@
 
 (re-frame/reg-event-fx
  ::init
- (fn [{:keys [db]} [_ {:keys [ws-url http-url http-parameters ws-reconnect-timeout resume-subscriptions?]
+ (fn [{:keys [db]} [_ {:keys [ws-url http-url http-parameters ws-reconnect-timeout resume-subscriptions? connection-init-payload]
                        :or {ws-url (internals/default-ws-url)
                             http-parameters {}
                             http-url "/graphql"
                             ws-reconnect-timeout 5000
+                            connection-init-payload {}
                             resume-subscriptions? true}}]]
 
    (merge
@@ -113,6 +114,7 @@
                               (when ws-url
                                 {:websocket {:url ws-url
                                              :ready? false
+                                             :connection-init-payload connection-init-payload
                                              :queue []
                                              :reconnect-timeout ws-reconnect-timeout
                                              :resume-subscriptions? resume-subscriptions?}})


### PR DESCRIPTION
Hello,

This is a follow-up of the discussion here: https://github.com/oliyh/re-graph/issues/19 

We need to send `connection_init` message before any other one, that's why I propose a new handler `::connection-init` that can be prepended in `::on-ws-open` dispatch.

As for the changes in the tests, I had to mock `::internals/send-ws` because some tests don't override it and the thus they try to send a message on a websocket that doesn't exist.