### PR TITLE
Fix/destroyed instance errors

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,3 @@
+{:deps {re-frame {:mvn/version "0.10.6"}
+        cljs-http {:mvn/version "0.1.45"}}
+ :paths ["src"]}

--- a/src/re_graph/core.cljs
+++ b/src/re_graph/core.cljs
@@ -1,6 +1,6 @@
 (ns re-graph.core
   (:require [re-frame.core :as re-frame]
-            [re-graph.internals :as internals :refer [interceptors default-instance-name]]
+            [re-graph.internals :as internals :refer [interceptors default-instance-name destroyed-instance]]
             [re-frame.std-interceptors :as rfi]
             [clojure.string :as string]))
 
@@ -165,7 +165,7 @@
       :dispatch [::destroy instance-name]}
 
      (merge
-      {:db nil}
+      {:db destroyed-instance}
       (when-let [ws (get-in db [:websocket :connection])]
         {::internals/disconnect-ws [ws]})))))
 

--- a/src/re_graph/internals.cljs
+++ b/src/re_graph/internals.cljs
@@ -9,6 +9,8 @@
 
 (def default-instance-name ::default)
 
+(def destroyed-instance ::destroyed-instance)
+
 (defn- cons-interceptor [ctx interceptor]
   (update ctx :queue #(into (into empty-queue [interceptor]) %)))
 
@@ -23,7 +25,11 @@
                    instance (get re-graph instance-name)
                    event-name (first (get-coeffect ctx ::rfi/untrimmed-event))
                    trimmed-event (if (= provided-instance-name instance-name) (subvec event 1) event)]
-               (if instance
+               (cond
+                 (= instance ::destroyed-instance)
+                 ctx
+
+                 instance
                  (-> ctx
                      (assoc-coeffect :instance instance)
                      (assoc-coeffect :instance-name instance-name)
@@ -31,6 +37,7 @@
                      (cons-interceptor (rfi/path :re-graph instance-name))
                      (assoc-coeffect :event trimmed-event))
 
+                 :default
                  (do (js/console.error "No default instance of re-graph found but no valid instance name was provided. Valid instance names are:" (keys re-graph)
                                        "but was provided with" provided-instance-name
                                        "handling event" event-name)

--- a/test/re_graph/core_test.cljs
+++ b/test/re_graph/core_test.cljs
@@ -1,6 +1,6 @@
 (ns re-graph.core-test
   (:require [re-graph.core :as re-graph]
-            [re-graph.internals :as internals :refer [default-instance-name]]
+            [re-graph.internals :as internals :refer [default-instance-name destroyed-instance]]
             [re-frame.core :as re-frame]
             [re-frame.db :refer [app-db]]
             [day8.re-frame.test :refer-macros [run-test-sync run-test-async wait-for]]
@@ -187,8 +187,8 @@
 
        (dispatch [::re-graph/destroy])
 
-       (testing "the re-graph state is no more"
-         (is (nil? (db-instance))))))))
+       (testing "the re-graph state is set to destroyed instance"
+         (is (= (db-instance) destroyed-instance)))))))
 
 (deftest websocket-lifecycle-test
   (run-websocket-lifecycle-test nil))


### PR DESCRIPTION
- Instead of replacing the instance with nil on ::destroy, place a destroyed instance so that the interceptor does not complain about a missing instance.