### PR TITLE
check existence of js/window to avoid undefined access

### DIFF
--- a/src/re_graph/internals.cljc
+++ b/src/re_graph/internals.cljc
@@ -244,7 +244,7 @@
 
 (defn default-ws-url []
   #?(:cljs
-     (when (exists? (.-location js/window))
+     (when (and (exists? js/window) (exists? (.-location js/window)))
        (let [host-and-port (.-host js/window.location)
              ssl? (re-find #"^https" (.-origin js/window.location))]
          (str (if ssl? "wss" "ws") "://" host-and-port "/graphql-ws")))


### PR DESCRIPTION
I'm using re-graph in a node environment for running automated functional tests against a GraphQL server. A dependency on `js/window` causes the re-graph initialization to fail, even if the `:ws-url` is set explicitly to nil. This PR introduces an additional check to avoid this problem in non-browser environments.
