### PR TITLE
use same function signature for query and mutate functions

### DIFF
--- a/src/re_graph/core.cljc
+++ b/src/re_graph/core.cljc
@@ -34,7 +34,7 @@
                                 :payload {:query query
                                           :variables variables}}]}))))
 
-(defn mutate [args]
+(defn mutate [& args]
   (let [callback-fn (last args)]
     (re-frame/dispatch (into [::mutate] (conj (vec (butlast args)) [::internals/callback callback-fn])))))
 


### PR DESCRIPTION
In the commit af116891b5ababdadad5772f500523878c618c3a, the function signature for `mutate` changed from using inline arguments to a single vector argument. This looks to have been an accidental change as the `query` function still uses inline arguments. This PR changes the `mutate` function signature to be consistent with the `query` function.