### PR TITLE
add synchronous versions of query and mutate

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,7 @@
-{:deps {re-frame {:mvn/version "0.10.6"}
-        cljs-http {:mvn/version "0.1.45"}}
+{:deps  {re-frame                  {:mvn/version "0.10.6"}
+         cljs-http                 {:mvn/version "0.1.45"}
+         clj-http                  {:mvn/version "3.9.1"}
+         stylefruits/gniazdo       {:mvn/version "1.1.1"}
+         cheshire                  {:mvn/version "5.8.1"}
+         org.clojure/tools.logging {:mvn/version "0.4.1"}}
  :paths ["src"]}

--- a/src/re_graph/core.cljc
+++ b/src/re_graph/core.cljc
@@ -52,12 +52,23 @@
            {:errors [{:status 500, :message "GraphQL request timed out", :args args}]}
            result)))))
 
-(defn mutate [& args]
+(defn mutate
+  "Execute a GraphQL mutation. The arguments are:
+
+  [instance-name query-string variables callback]
+
+  If the optional `instance-name` is not provided, the default instance is
+  used. The callback function will receive the result of the mutation as its
+  sole argument."
+  [& args]
   (let [callback-fn (last args)]
     (re-frame/dispatch (into [::mutate] (conj (vec (butlast args)) [::internals/callback callback-fn])))))
 
 #?(:clj
-   (def mutate-sync (partial sync-wrapper mutate 3000)))    ;; 3s timeout
+   (def ^{:doc "Executes a mutation synchronously. Takes the same arguments as
+                `mutate` but without the callback."}
+     mutate-sync
+     (partial sync-wrapper mutate 3000)))    ;; 3s timeout
 
 (re-frame/reg-event-fx
  ::query
@@ -89,12 +100,23 @@
                                 :payload {:query query
                                           :variables variables}}]}))))
 
-(defn query [& args]
+(defn query
+  "Execute a GraphQL query. The arguments are:
+
+  [instance-name query-string variables callback]
+
+  If the optional `instance-name` is not provided, the default instance is
+  used. The callback function will receive the result of the query as its
+  sole argument."
+  [& args]
   (let [callback-fn (last args)]
     (re-frame/dispatch (into [::query] (conj (vec (butlast args)) [::internals/callback callback-fn])))))
 
 #?(:clj
-   (def query-sync (partial sync-wrapper query 3000)))      ;; 3s timeout
+   (def ^{:doc "Executes a query synchronously. Takes the same arguments as
+                `query` but without the callback."}
+     query-sync 
+     (partial sync-wrapper query 3000)))      ;; 3s timeout
 
 (re-frame/reg-event-fx
  ::abort

--- a/src/re_graph/core.cljc
+++ b/src/re_graph/core.cljc
@@ -43,7 +43,6 @@
      (let [p        (promise)
            callback (fn [result] (deliver p result))
            args'    (conj (vec args) callback)]
-       (println f timeout " --> " args')
        (apply f args')
 
        ;; explicit timeout to avoid unreliable aborts from underlying implementations
@@ -115,7 +114,7 @@
 #?(:clj
    (def ^{:doc "Executes a query synchronously. Takes the same arguments as
                 `query` but without the callback."}
-     query-sync 
+     query-sync
      (partial sync-wrapper query 3000)))      ;; 3s timeout
 
 (re-frame/reg-event-fx

--- a/src/re_graph/core.cljc
+++ b/src/re_graph/core.cljc
@@ -34,7 +34,7 @@
                                 :payload {:query query
                                           :variables variables}}]}))))
 
-(defn mutate [args]
+(defn mutate [& args]
   (let [callback-fn (last args)]
     (re-frame/dispatch (into [::mutate] (conj (vec (butlast args)) [::internals/callback callback-fn])))))
 

--- a/src/re_graph/core.cljc
+++ b/src/re_graph/core.cljc
@@ -43,6 +43,7 @@
      (let [p        (promise)
            callback (fn [result] (deliver p result))
            args'    (conj (vec args) callback)]
+       (println f timeout " --> " args')
        (apply f args')
 
        ;; explicit timeout to avoid unreliable aborts from underlying implementations

--- a/src/re_graph/core.cljc
+++ b/src/re_graph/core.cljc
@@ -48,7 +48,7 @@
        ;; explicit timeout to avoid unreliable aborts from underlying implementations
        (let [result (deref p timeout :timeout)]
          (if (= :timeout result)
-           {:errors [{:status 500, :message "graphql request timed out", :args args}]}
+           {:errors [{:status 500, :message "GraphQL request timed out", :args args}]}
            result)))))
 
 (defn mutate [& args]


### PR DESCRIPTION
In addition to using re-graph for a browser-based UI, I'm also using it on the server-side to execute integration tests. In this context, having synchronous versions of query and mutate are useful to reduce the complexity of the test source code. In the hope that these may also be useful to others, this PR adds `query-sync` and `mutate-sync` functions. I've also added docstrings, as the new argument lists are not very useful for understanding the required parameters.