### PR TITLE
if sub-protocol is nil, don't use it in constructor

### DIFF
--- a/src/re_graph/internals.cljc
+++ b/src/re_graph/internals.cljc
@@ -274,7 +274,11 @@
 (re-frame/reg-fx
  ::connect-ws
  (fn [[instance-name ws-url sub-protocol]]
-   #?(:cljs (let [ws (js/WebSocket. ws-url sub-protocol)]
+   #?(:cljs (let [ws (cond
+                       (nil? sub-protocol)
+                       (js/WebSocket. ws-url)
+                       :else ;; non-nil sub protocol
+                       (js/WebSocket. ws-url sub-protocol))]
               (aset ws "onmessage" (on-ws-message instance-name))
               (aset ws "onopen" (on-open instance-name ws))
               (aset ws "onclose" (on-close instance-name))


### PR DESCRIPTION
Minor edit.  conditional to check if the sub-protocol is nil, then don't use it when constructing the websocket.  Otherwise, sub-protocol is still sent as nil, whereas the expected behavior is to not send any sub-protocols