### PR TITLE
fix(hato): reuse a single HttpClient to avoid RejectedExecutionException (#75)

### DIFF
--- a/hato/project.clj
+++ b/hato/project.clj
@@ -1,2 +1,2 @@
 (defproject re-graph.hato "0.2.1-SNAPSHOT"
-  :dependencies [[hato "0.8.2"]])
+  :dependencies [[hato "1.0.0"]])

--- a/hato/src/re_graph/interop.clj
+++ b/hato/src/re_graph/interop.clj
@@ -2,8 +2,17 @@
   (:require [hato.client :as hato-http]
             [hato.websocket :as hato-ws]))
 
+;; Reuse a single HttpClient across requests. java.net.http.HttpClient owns an
+;; executor, and on JDK 21+ an unreferenced client can be closed (shutting down
+;; that executor) before an in-flight async callback runs, yielding a
+;; RejectedExecutionException. A long-lived client keeps the executor alive and
+;; also reuses the connection pool.
+(defonce ^:private http-client
+  (hato-http/build-http-client {:connect-timeout 10000}))
+
 (defn create-ws [url {:keys [on-message on-error] :as callbacks}]
   (hato-ws/websocket url (assoc callbacks
+                           :http-client http-client
                            ;; See `java.net.http.WebSocket/request` docs for more details on `last?`
                            :on-message (let [text-buffer (atom (StringBuilder.))]
                                          (fn [_ws message last?]
@@ -28,6 +37,7 @@
                       (update :headers merge {"Content-Type" "application/json"
                                               "Accept" "application/json"})
                       (merge {:body payload
+                              :http-client http-client
                               :as :json
                               :coerce :always
                               :async? true


### PR DESCRIPTION
Likely fixes #75.

re-graph sends every HTTP and WebSocket request through a freshly built `java.net.http.HttpClient`. On JDK 21+ a `HttpClient` that becomes unreferenced can be closed by the runtime, which shuts down its internal executor. If that happens before an in-flight async response callback runs, the request fails with `RejectedExecutionException` and the caller simply times out waiting for a response that never arrives - the "hangs in clojure" symptom in #75.

Hold one long-lived `HttpClient` in the hato interop and pass it to every request and websocket. The executor stays alive for the life of the process, and the connection pool is reused as a bonus.

This also bumps the hato wrapper to hato 1.0.0 (the `:http-client` option is passed to both `hato.client/post` and `hato.websocket/websocket`).

Verified against the integration suite on JDK 21: the websocket and async-HTTP integration tests, which time out without this change, pass with it.
