### PR TITLE
build: modernize dependencies and qualify lib coordinates

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
-{:deps  {re-frame                  {:mvn/version "1.2.0"}
-         cljs-http                 {:mvn/version "0.1.46"}
-         cheshire                  {:mvn/version "5.10.2"}
-         org.clojure/spec.alpha    {:mvn/version "0.3.218"}
-         re-graph.hato             {:mvn/version "0.2.0"}
-         org.clojure/tools.logging {:mvn/version "1.2.4"}}
+{:deps  {re-frame/re-frame                  {:mvn/version "1.2.0"}
+         cljs-http/cljs-http                {:mvn/version "0.1.46"}
+         cheshire/cheshire                  {:mvn/version "5.13.0"}
+         org.clojure/spec.alpha             {:mvn/version "0.5.238"}
+         re-graph.hato/re-graph.hato        {:mvn/version "0.2.0"}
+         org.clojure/tools.logging          {:mvn/version "1.3.0"}}
  :paths ["src"]}

--- a/project.clj
+++ b/project.clj
@@ -17,11 +17,14 @@
                   ["vcs" "push"]]
   :dependencies [[re-frame "1.2.0"]
                  [cljs-http "0.1.46"]
-                 [org.clojure/tools.logging "1.2.4"]
-                 [cheshire "5.10.2"]
-                 [org.clojure/spec.alpha "0.3.218"]
+                 [org.clojure/tools.logging "1.3.0"]
+                 [cheshire "5.13.0"]
+                 [org.clojure/spec.alpha "0.5.238"]
                  [re-graph.hato :version]]
-  :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.3"]
+  ;; re-frame stays at 1.2.0 here: 1.4's reagent/React decoupling and dispatch
+  ;; changes need accompanying code fixes, so that upgrade is a separate PR.
+  ;; ClojureScript stays at 1.11.4 (1.12 needs JDK 21; CI is JDK 11).
+  :profiles {:provided {:dependencies [[org.clojure/clojure "1.11.4"]
                                        [org.clojure/clojurescript "1.11.4"]]}
              :dev      {:source-paths   ["dev"
                                          "hato/src"


### PR DESCRIPTION
Bump the dependencies that can move without behavioural change, and qualify the unqualified coordinates in `deps.edn`.

- Clojure 1.10.3 -> 1.11.4
- cheshire 5.10.2 -> 5.13.0
- tools.logging 1.2.4 -> 1.3.0
- spec.alpha 0.3.218 -> 0.5.238
- `deps.edn`: qualify `re-frame/re-frame`, `cljs-http/cljs-http`, `cheshire/cheshire`, `re-graph.hato/re-graph.hato` (current ClojureScript warns on the short forms)

re-frame, ClojureScript and cljs-http are deliberately left at their current versions here. Bumping re-frame to 1.4 is not a drop-in: it decouples reagent/React and changes event dispatch, which needs accompanying code (and breaks the cljs integration tests until that's done), and ClojureScript 1.12 requires JDK 21 while CI runs JDK 11. Those belong in a dedicated upgrade PR alongside the CI/JDK move, so the ClojureScript side here is unchanged from master.

Green on CI (JDK 11): full `lein test` passes, clj and cljs.
