### PR TITLE
feat: support the graphql-transport-ws subscription protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Features include:
   - [Cookies](#cookies)
   - [Token in query param](#token-in-query-param)
   - [Basic auth](#basic-auth)
+  - [Subscription protocol](#subscription-protocol)
   - [Sub-protocol hack](#sub-protocol-hack)
 - [Re-initialisation](#re-initialisation)
 - [Development](#development)
@@ -142,7 +143,7 @@ Options can be passed to the init event, with the following possibilities:
 (re-frame/dispatch
   [::re-graph/init
    {:ws {:url                     "wss://foo.io/graphql-ws" ;; override the websocket url (defaults to /graphql-ws, nil to disable)
-         :sub-protocol            "graphql-ws"              ;; override the websocket sub-protocol (defaults to "graphql-ws")
+         :sub-protocol            "graphql-ws"              ;; websocket sub-protocol: "graphql-ws" (legacy, default) or "graphql-transport-ws" (modern)
          :reconnect-timeout       5000                      ;; attempt reconnect n milliseconds after disconnect (defaults to 5000, nil to disable)
          :resume-subscriptions?   true                      ;; start existing subscriptions again when websocket is reconnected after a disconnect (defaults to true)
          :connection-init-payload {}                        ;; the payload to send in the connection_init message, sent when a websocket connection is made (defaults to {})
@@ -214,6 +215,7 @@ There are several methods of authenticating with the server, with various trade-
 - [Cookies](#cookies)
 - [Token in query param](#token-in-query-param)
 - [Basic auth](#basic-auth)
+- [Subscription protocol](#subscription-protocol)
 - [Sub-protocol hack](#sub-protocol-hack)
 
 ### Headers
@@ -298,6 +300,22 @@ You can put basic auth in the http and websocket urls and use it to authenticate
     {:http {:url "https://my-user:my-password@my-server.com/graphql"}
      :ws {:url "wss://my-user:my-password@my-server.com/graphql-ws"}}])
 ```
+
+### Subscription protocol
+
+re-graph supports two websocket sub-protocols, selected with `:sub-protocol`:
+
+- `"graphql-ws"` (the default) - the legacy [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) protocol.
+- `"graphql-transport-ws"` - the modern [graphql-ws](https://github.com/enisdenjo/graphql-ws) protocol, used by Apollo Server 3+, graphql-yoga, Hasura and AWS AppSync.
+
+```clojure
+(re-frame/dispatch
+  [::re-graph/init
+    {:ws {:url "wss://foo.io/graphql"
+          :sub-protocol "graphql-transport-ws"}}])
+```
+
+Under `graphql-transport-ws`, re-graph waits for the server's `connection_ack` before sending any operations and answers server `ping` messages with `pong`, as the protocol requires. The default remains the legacy protocol, so existing configurations are unaffected.
 
 ### Sub-protocol hack
 

--- a/src/re_graph/core.cljc
+++ b/src/re_graph/core.cljc
@@ -27,7 +27,7 @@
        {:db (assoc-in db [:subscriptions id] {:callback callback})
         ::internals/send-ws [(get-in db [:ws :connection])
                              {:id id
-                              :type "start"
+                              :type (internals/ws-message-type db :subscribe)
                               :payload {:query query
                                         :variables variables}}]}
 
@@ -78,7 +78,7 @@
                                               :legacy? legacy?})
         ::internals/send-ws [(get-in db [:ws :connection])
                              {:id id
-                              :type "start"
+                              :type (internals/ws-message-type db :subscribe)
                               :payload {:query query
                                         :variables variables}}]}
 
@@ -142,7 +142,7 @@
                                                                 :legacy? legacy?})
       ::internals/send-ws [(get-in db [:ws :connection])
                            {:id (name id)
-                            :type "start"
+                            :type (internals/ws-message-type db :subscribe)
                             :payload {:query (str "subscription " (string/replace query #"^subscription\s?" ""))
                                       :variables variables}}]}
 
@@ -171,7 +171,7 @@
      {:db (update db :subscriptions dissoc (name id))
       ::internals/send-ws [(get-in db [:ws :connection])
                            {:id (name id)
-                            :type "stop"}]}
+                            :type (internals/ws-message-type db :complete)}]}
 
      {:db (update-in db [:ws :queue] conj [::unsubscribe event])})))
 

--- a/src/re_graph/internals.cljc
+++ b/src/re_graph/internals.cljc
@@ -29,6 +29,28 @@
                (js->clj :keywordize-keys true))
      :clj (json/decode m keyword)))
 
+;; Two websocket sub-protocols are supported, selected by the :sub-protocol
+;; option: the legacy "graphql-ws" (apollographql/subscriptions-transport-ws)
+;; and the modern "graphql-transport-ws" (the graphql-ws spec by enisdenjo).
+;; They share connection_init/connection_ack but differ in the operation
+;; message names, so outgoing messages look up their wire type here.
+(def ^:private ws-protocol-messages
+  {"graphql-ws"           {:subscribe "start", :complete "stop"}
+   "graphql-transport-ws" {:subscribe "subscribe", :complete "complete"}})
+
+(defn transport-ws?
+  "True if this instance is configured for the modern graphql-transport-ws
+  sub-protocol (which requires waiting for connection_ack before subscribing)."
+  [db]
+  (= "graphql-transport-ws" (get-in db [:ws :sub-protocol])))
+
+(defn ws-message-type
+  "Wire message type for a logical operation (:subscribe / :complete) under the
+  sub-protocol configured for this instance, defaulting to the legacy names."
+  [db op]
+  (or (get-in ws-protocol-messages [(get-in db [:ws :sub-protocol]) op])
+      (get-in ws-protocol-messages ["graphql-ws" op])))
+
 (defn generate-id []
   #?(:cljs (.substr (.toString (Math/random) 36) 2 8)
      :clj (str (UUID/randomUUID))))
@@ -210,27 +232,50 @@
  (fn [{:keys [db]} _]
     (let [ws (get-in db [:ws :connection])
           payload (get-in db [:ws :connection-init-payload])]
-      (when payload
-        {::send-ws [ws {:type "connection_init"
-                        :payload payload}]}))))
+      ;; graphql-transport-ws requires connection_init to be sent always (the
+      ;; server replies connection_ack); legacy only sends it with a payload.
+      (when (or (transport-ws? db) payload)
+        {::send-ws [ws (cond-> {:type "connection_init"}
+                         payload (assoc :payload payload))]}))))
+
+(defn- resume-dispatches
+  "Events to (re)send once the connection is usable: resumed subscriptions plus
+  anything queued while the socket was down."
+  [db]
+  (let [resume? (get-in db [:ws :resume-subscriptions?])
+        subscriptions (when resume? (->> db :subscriptions vals (map :event)))
+        queue (get-in db [:ws :queue])]
+    (vec (concat subscriptions queue))))
 
 (re-frame/reg-event-fx
  ::on-ws-open
  (interceptors)
  (fn [{:keys [db]} {:keys [instance-id websocket]}]
-   (merge
-    {:db (update db :ws
-                    assoc
-                    :connection websocket
-                    :ready? true
-                    :queue [])}
-    (let [resume? (get-in db [:ws :resume-subscriptions?])
-          subscriptions (when resume? (->> db :subscriptions vals (map :event)))
-          queue (get-in db [:ws :queue])
-          to-send (concat [[::connection-init {:instance-id instance-id}]]
-                          subscriptions
-                          queue)]
-      {:dispatch-n (vec to-send)}))))
+   (if (transport-ws? db)
+     ;; modern: register the connection and send connection_init, but stay
+     ;; not-ready (queuing operations) until the server sends connection_ack.
+     {:db (assoc-in db [:ws :connection] websocket)
+      :dispatch [::connection-init {:instance-id instance-id}]}
+     ;; legacy: ready immediately, send connection_init then flush.
+     (merge
+      {:db (update db :ws assoc :connection websocket :ready? true :queue [])}
+      {:dispatch-n (into [[::connection-init {:instance-id instance-id}]]
+                         (resume-dispatches db))}))))
+
+(re-frame/reg-event-fx
+ ::on-ws-ack
+ (interceptors)
+ (fn [{:keys [db]} _]
+   ;; graphql-transport-ws: connection is usable now - go ready and flush.
+   (when (transport-ws? db)
+     {:db (update db :ws assoc :ready? true :queue [])
+      :dispatch-n (resume-dispatches db)})))
+
+(re-frame/reg-event-fx
+ ::on-ws-ping
+ (interceptors)
+ (fn [{:keys [db]} _]
+   {::send-ws [(get-in db [:ws :connection]) {:type "pong"}]}))
 
 (defn- deactivate-subscriptions [subscriptions]
   (reduce-kv (fn [subs sub-id sub]
@@ -256,21 +301,32 @@
   (fn [m]
     (try
       (let [{:keys [type id payload]} (message->data m)]
-        (condp = type
-          "data"
+        (cond
+          ;; "data" (legacy) and "next" (graphql-transport-ws) carry results
+          (contains? #{"data" "next"} type)
           (re-frame/dispatch [::on-ws-data {:instance-id instance-id
                                             :id          id
                                             :payload     payload}])
 
-          "complete"
+          (= "complete" type)
           (re-frame/dispatch [::on-ws-complete {:instance-id instance-id
                                                 :id          id}])
 
-          "error"
+          (= "error" type)
           (re-frame/dispatch [::on-ws-data {:instance-id instance-id
                                             :id          id
                                             :payload     {:errors payload}}])
 
+          ;; graphql-transport-ws: subscriptions may only be sent after ack
+          (= "connection_ack" type)
+          (re-frame/dispatch [::on-ws-ack {:instance-id instance-id}])
+
+          ;; graphql-transport-ws keepalive - reply to keep the socket open
+          (= "ping" type)
+          (re-frame/dispatch [::on-ws-ping {:instance-id instance-id}])
+
+          ;; ignore "ka" (legacy keepalive), "pong", and anything unknown
+          :else
           (log/debug "Ignoring graphql-ws event " instance-id " - " type)))
       (catch #?(:clj Exception :cljs js/Object) e
         (log/error e "Failed to handle graphql-ws event " instance-id " - " m)))))

--- a/test/re_graph/core_test.cljc
+++ b/test/re_graph/core_test.cljc
@@ -133,6 +133,61 @@
 (deftest named-subscription-test
   (run-subscription-test :service-a))
 
+(defn- run-transport-ws-subscription-test [instance-id]
+  (let [dispatch (partial dispatch-to-instance instance-id)
+        on-ws-message (on-ws-message (or instance-id default-instance-id))
+        sent (atom [])]
+    (run-test-sync
+     (install-websocket-stub!)
+     (re-frame/reg-fx ::internals/send-ws (fn [[_ws payload]] (swap! sent conj payload)))
+     (init instance-id {:ws {:url "ws://socket.rocket"
+                             :sub-protocol "graphql-transport-ws"
+                             :connection-init-payload nil}})
+
+     (testing "connection_init is sent on open"
+       (is (= [{:type "connection_init"}] @sent)))
+
+     (testing "subscriptions wait for connection_ack, then send as 'subscribe'"
+       (dispatch [::re-graph/subscribe {:id :my-sub
+                                        :query "{ things { id } }"
+                                        :variables {:some "variable"}
+                                        :callback [::on-thing]}])
+       ;; not acked yet: still only the connection_init message
+       (is (= 1 (count @sent)))
+
+       (on-ws-message (data->message {:type "connection_ack"}))
+
+       (is (= {:id "my-sub"
+               :type "subscribe"
+               :payload {:query "subscription { things { id } }"
+                         :variables {:some "variable"}}}
+              (last @sent))))
+
+     (testing "'next' messages are sent to the callback"
+       (let [expected {:data {:things [{:id 1} {:id 2}]}}]
+         (re-frame/reg-event-db
+          ::on-thing
+          [re-frame/unwrap]
+          (fn [db {:keys [response]}] (assoc db ::thing response)))
+         (on-ws-message (data->message {:type "next" :id "my-sub" :payload expected}))
+         (is (= expected (::thing @app-db)))))
+
+     (testing "'ping' is answered with 'pong'"
+       (reset! sent [])
+       (on-ws-message (data->message {:type "ping"}))
+       (is (= [{:type "pong"}] @sent)))
+
+     (testing "unsubscribe sends 'complete'"
+       (reset! sent [])
+       (dispatch [::re-graph/unsubscribe {:id :my-sub}])
+       (is (= {:id "my-sub" :type "complete"} (last @sent)))))))
+
+(deftest transport-ws-subscription-test
+  (run-transport-ws-subscription-test nil))
+
+(deftest named-transport-ws-subscription-test
+  (run-transport-ws-subscription-test :service-a))
+
 (defn- run-websocket-lifecycle-test [instance-id]
   (let [dispatch (partial dispatch-to-instance instance-id)
         db-instance #(get-in @app-db [:re-graph (or instance-id default-instance-id)])


### PR DESCRIPTION
Relates to #98.

re-graph currently speaks only the legacy `subscriptions-transport-ws` protocol (the `graphql-ws` sub-protocol: `connection_init` / `start` / `stop` / `data`). That protocol was deprecated/archived years ago, and modern servers - Apollo Server 3+, graphql-yoga, Hasura, and **AWS AppSync** (#98) - use the newer `graphql-transport-ws` protocol instead, so re-graph currently can't talk to them over websockets.

This adds support for `graphql-transport-ws`, selected with:

```clojure
{:ws {:sub-protocol "graphql-transport-ws"}}
```

The legacy protocol stays the default, so existing users are unaffected. Differences handled:

- operation messages: `start` -> `subscribe`, `stop` -> `complete`
- result messages: accept both `data` (legacy) and `next` (modern)
- `connection_init` is always sent, and operations now wait for the server's `connection_ack` before being sent (the socket stays not-ready and queues until ack), as the spec requires
- reply to server `ping` with `pong` (keepalive)

Implemented in the shared `.cljc` so it works on both JVM and ClojureScript. Tested: new `transport-ws-subscription-test` (+ named variant) covering the ack gating, `subscribe`/`next`/`complete`, and ping/pong; the existing legacy subscription tests are unchanged and still pass. Full clj suite green; cljc compiles for cljs.
